### PR TITLE
More target=_blank; fix partially-obscured button.

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -35,11 +35,11 @@ const Footer = ({ whiteFooter }) => (
     <img src={cncfLogo} alt='CNCF logo' className={styles.logo} />
     <div className={styles.copyrightBar}>
       <div className={styles.verticalCenter}>
-        <Link to='https://www.linuxfoundation.org/terms' className={styles.mutedLink}>Terms of Service</Link>
+        <Link to='https://www.linuxfoundation.org/terms' target='_blank' rel='noreferrer' className={styles.mutedLink}>Terms of Service</Link>
         <span>
           |
         </span>
-        <Link to='https://www.linuxfoundation.org/privacy' className={styles.mutedLink}>Privacy Policy</Link>
+        <Link to='https://www.linuxfoundation.org/privacy' target='_blank' rel='noreferrer' className={styles.mutedLink}>Privacy Policy</Link>
       </div>
       <div className={styles.centerContent}>
         Copyright © 2018- The Pixie Authors. All Rights Reserved.

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -83,14 +83,14 @@ const Header = ({ whiteHeader, transparentMenu }) => {
           <span className='hide-not-desktop'>
             Export Pixie data in the OpenTelemetry format.
             {' '}
-            <a href='http://blog.px.dev/plugin-system/'>
+            <a href='http://blog.px.dev/plugin-system/' target='_blank' rel='noreferrer'>
               Learn more
             </a>
             {' '}
              🚀
           </span>
           <span className='hide-desktop'>
-            <a href='http://blog.px.dev/plugin-system/'>Pixie has an OpenTelemetry plugin!</a>
+            <a href='http://blog.px.dev/plugin-system/' target='_blank' rel='noreferrer'>Pixie has an OpenTelemetry plugin!</a>
           </span>
           <div
             className={`${styles.newsBarClose} hide-desktop`}
@@ -116,16 +116,16 @@ const Header = ({ whiteHeader, transparentMenu }) => {
             <img src={pixieLogo} alt='pixie logo' />
           </Link>
           <div className={styles.socialIcons}>
-            <a href='https://slackin.px.dev'>
+            <a href='https://slackin.px.dev' target='_blank' rel='noreferrer'>
               <img src={slack} alt='slack' />
             </a>
-            <a href='https://github.com/pixie-io/pixie'>
+            <a href='https://github.com/pixie-io/pixie' target='_blank' rel='noreferrer'>
               <img src={github} alt='github' />
             </a>
-            <a href='https://twitter.com/pixie_run'>
+            <a href='https://twitter.com/pixie_run' target='_blank' rel='noreferrer'>
               <img src={twitter} alt='twitter' />
             </a>
-            <a href='https://www.youtube.com/channel/UCOMCDRvBVNIS0lCyOmst7eg/featured'>
+            <a href='https://www.youtube.com/channel/UCOMCDRvBVNIS0lCyOmst7eg/featured' target='_blank' rel='noreferrer'>
               <img src={youtube} alt='youtube' />
             </a>
           </div>
@@ -228,9 +228,9 @@ const Header = ({ whiteHeader, transparentMenu }) => {
               </li>
             </ul>
 
-            <Link to='https://www.linuxfoundation.org/terms'>Terms of Service</Link>
+            <Link to='https://www.linuxfoundation.org/terms' target='_blank' rel='noreferrer'>Terms of Service</Link>
             <br />
-            <Link to='https://www.linuxfoundation.org/privacy'>Privacy Policy</Link>
+            <Link to='https://www.linuxfoundation.org/privacy' target='_blank' rel='noreferrer'>Privacy Policy</Link>
           </div>
         </div>
         <IconButton onClick={() => setOpen(true)} className='hide-desktop'>

--- a/src/scss/pages/index.module.scss
+++ b/src/scss/pages/index.module.scss
@@ -537,6 +537,7 @@
       float: right;
       text-align: left;
       padding-bottom: 150px;
+      position: relative; /* Otherwise, the z-index: 0 on the image above causes it to overlap the button. */
 
       h2 {
         text-align: left;


### PR DESCRIPTION
Adds `target="_blank" rel="noreferrer"` to more header/footer links.
Prevents a splash image near the "Be a Pixienaut" button from obscuring the clickable area.

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>
